### PR TITLE
feat: add support for integer variables

### DIFF
--- a/bayex/gp.py
+++ b/bayex/gp.py
@@ -6,11 +6,12 @@ from typing import Any, Callable, Tuple
 
 import jax.numpy as jnp
 import jax.scipy as scipy
-from jax import grad, jit, lax, tree_map, tree_multimap, vmap
+from jax import grad, jit, lax, ops, tree_map, tree_multimap, vmap
 
 Array = Any  # waiting for JAX official type support
 
 GParameters = namedtuple("GParameters", ["noise", "amplitude", "lengthscale"])
+DataTypes = namedtuple("DataTypes", ["integers"])
 
 
 def cov_map(cov_func: Callable, xs: Array, xs2: Array = None) -> Array:
@@ -32,10 +33,22 @@ def exp_quadratic(x1: Array, x2: Array) -> Array:
     return jnp.exp(-jnp.sum((x1 - x2) ** 2))
 
 
+@jit
+def round_vars(arr: Array, indexes: list) -> Array:
+    """
+    The input variables corresponding to an integer-valued input variable are
+    rounded to the closest integer value.
+    """
+    for idx in indexes:
+        arr = ops.index_update(arr, ops.index[:, idx], jnp.round(arr[:, idx]))
+    return arr
+
+
 def gp(
     params: GParameters,
     x: Array,
     y: Array,
+    dtypes: DataTypes,
     xt: Array = None,
     compute_ml: bool = False,
 ) -> Any:
@@ -59,7 +72,7 @@ def gp(
     Gaussian Distributions.
     """
     n = x.shape[0]
-
+    x = round_vars(x, dtypes.integers)
     noise, amp, ls = tree_map(softplus, params)
 
     ymean = jnp.mean(y)
@@ -81,6 +94,7 @@ def gp(
         return -ml
 
     if xt is not None:
+        xt = round_vars(xt, dtypes.integers)
         xt = xt / ls
 
     cross_cov = amp * cov_map(exp_quadratic, x, xt)
@@ -106,12 +120,13 @@ def train_step(
     scales: GParameters,
     x: Array,
     y: Array,
+    dtypes: DataTypes,
     lr: float = 0.01,
 ) -> Tuple[GParameters, GParameters, GParameters]:
     """
     Training step of the Gaussian Process Regressor.
     """
-    grads = grad_fun(params, x, y)
+    grads = grad_fun(params, x, y, dtypes=dtypes)
     momentums = tree_multimap(lambda m, g: 0.9 * m + 0.1 * g, momentums, grads)
     scales = tree_multimap(lambda s, g: 0.9 * s + 0.1 * g ** 2, scales, grads)
     params = tree_multimap(
@@ -130,6 +145,7 @@ def train(
     params: GParameters,
     momentums: GParameters,
     scales: GParameters,
+    dtypes: DataTypes,
     lr: float = 0.01,
     nsteps: int = 20,
 ) -> Tuple[GParameters, GParameters, GParameters]:
@@ -152,7 +168,7 @@ def train(
     params, momentums, scales = lax.fori_loop(
         0,
         nsteps,
-        lambda _, v: train_step(v[0], v[1], v[2], x, y, lr),
+        lambda _, v: train_step(v[0], v[1], v[2], x, y, dtypes, lr),
         (params, momentums, scales),
     )
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -36,12 +36,12 @@ def test_2D_optim():
     params = bayex.optim(f, constrains=bounds, seed=SEED, n=15, n_init=10)
     assert jnp.allclose(TARGET, params.target, rtol=1e-01)
 
-def test_optim_params_correct_output():
 
+def test_optim_params_correct_output():
     def f(x, y, z):
         return -(y ** 2) - (x - y) ** 2 + 3 * z / y - 2
 
-    bounds = dict(x=(0, 5), y=(1, 4), z=(1,20))
+    bounds = dict(x=(0, 5), y=(1, 4), z=(1, 20))
 
     param = bayex.optim(f, constrains=bounds, seed=SEED, n=2, n_init=2)
     assert type(param.target) == float
@@ -49,3 +49,14 @@ def test_optim_params_correct_output():
     assert len(param.parameters) == len(bounds)
 
 
+def test_cast_to_int():
+    def f(x, y, z):
+        return -(y ** 2) - (x - y) ** 2 + 3 * z / y - 2
+
+    bounds = dict(x=(0, 5), y=(1, 4), z=(1, 20))
+    ctypes = dict(z=int)
+
+    param = bayex.optim(
+        f, constrains=bounds, seed=SEED, n=2, n_init=2, ctypes=ctypes
+    )
+    assert int(param.parameters["z"]) == param.parameters["z"]


### PR DESCRIPTION
By passing a dictionary with the non-real variables, the optimizer will
round the values to their nearest integer before being sent to the
computed.

Solves #4 

### Possible issues it would be nice to have covered:
* The target function may expect a variable type `int`, be it for index accessing or some type checking, having rounded values is not enough. 
* The target function may not work with abstract tracers values (most likely), so nothing that is sent to the function can be a tracer. Some wrapping needs to happen, preferably without loosing too much performance.