### PR TITLE
feat: add results table function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,35 @@ def f(x, y):
 constrains = {'x': (-10, 10), 'y': (0, 10)}
 optim_params = bayex.optim(f, constrains=constrains, seed=42, n=10)
 ```
-```
-New sampled point: [4.5109005 7.4756947] --> -64.86578837717816
-New sampled point: [2.6784592 3.2219148] --> -10.18210295096584
-New sampled point: [5.567053  1.4345944] --> -9.493547303747564
-New sampled point: [2.7907293 3.224175 ] --> -9.98648791591534
-New sampled point: [6.3199263 1.7560012] --> -15.115816866848736
-New sampled point: [5.5886126 1.6345143] --> -10.049148003506835
-New sampled point: [5.712037  1.2171721] --> -9.606692998273038
-New sampled point: [2.6794453 3.0094016] --> -8.494294392550797
-New sampled point: [3.2767563 2.9352677] --> -7.383391309885405
-New sampled point: [3.1001327 2.7761958] --> -6.462146806424036
+showing the results can be done with
+```python
+>> bayex.show_results(optim_params, min_len=13)
+   #sample      target          x            y
+      1        -9.84385      2.87875      3.22516
+      2        -307.513     -6.13013      8.86493
+      3        -19.2197      6.8417       1.9193
+      4        -43.6495     -3.09738      2.52383
+      5        -58.9488      2.63803      6.54768
+      6        -64.8658      4.5109       7.47569
+      7        -78.5649      6.91026      8.70257
+      8        -9.49354      5.56705      1.43459
+      9        -9.59955      5.60318      1.39322
+     10        -15.4077      6.37659      1.5895
+     11        -11.7703      5.83045      1.80338
+     12        -11.4169      2.53303      3.32719
+     13        -8.49429      2.67945      3.0094
+     14        -9.17395      2.74325      3.11174
+     15        -7.35265      2.86541      2.88627
 ```
 we can then obtain the maximum value found using
 ```python
 >> optim_params.target
--6.4621468
+-7.352654457092285
 ```
 as well as the input parameters that yield it
 ```python
->> optim_params.parameters
-{'x': 3.1001327, 'y': 2.7761958}
+>> optim_params.params
+{'x': 2.865405, 'y': 2.8862667}
 ```
 
 ## Contributing

--- a/bayex/__init__.py
+++ b/bayex/__init__.py
@@ -1,5 +1,8 @@
 from .optim import optim
+from .screen import Log, show_results
 
 __all__ = [
     "optim",
+    "show_results",
+    "Log",
 ]

--- a/bayex/screen.py
+++ b/bayex/screen.py
@@ -1,0 +1,79 @@
+from enum import Enum
+from typing import Any, Callable
+
+import jax.numpy as jnp
+from jax._src.tree_util import tree_map
+
+from bayex.optim import OptimizerParameters
+
+Array = Any  # todo: fix jax type hinting
+
+
+class Log(Enum):
+    ALL = 1
+    BEST = 2
+
+
+def show_sampling(
+    x: Array, y: Array, f: Callable, verbose: Log, min_width: int
+) -> None:
+    """
+    Prints the sampled points during the optimization as well as the target
+    value.
+
+    Parameters:
+    -----------
+    x: The sampled points.
+    y: The sampled targets.
+    f: Target function.
+    verbose: Level of detail in the shown information.
+             - Log.ALL shows all the sampling points.
+             - Log.BEST shows only the iterations that find better results.
+    min_width: Minimum width of the column.
+    """
+    assert x.ndim == 2, "sampled points should be a 2d-array (throws, vars)"
+    var_count = x.shape[1]
+    assert var_count == f.__code__.co_argcount
+    var_names = f.__code__.co_varnames[:var_count]
+    max_width = max(tree_map(len, var_names))
+    max_width = max_width if max_width > min_width else min_width
+    col_template = "{:^" + str(max_width) + "}"
+    row_template = col_template * (var_count + 2)
+    print(row_template.format("#sample", "target", *var_names))
+    col_template = "{:^" + str(max_width) + "g}"
+    row_template = col_template * (var_count + 2)
+
+    # I doubt whether is should be better to print in sorted mode
+    # or is it better to show in the order they have been sampled
+    y_prev = -jnp.inf
+    for i, (xi, yi) in enumerate(zip(x, y)):
+        if verbose == Log.BEST and yi < y_prev:
+            continue
+        print(row_template.format(i + 1, yi, *xi))
+        y_prev = yi
+
+
+def show_results(
+    res: OptimizerParameters, verbose: Log = Log.ALL, min_width: int = 10
+) -> None:
+    """
+    Prints the sampled points during the optimization as well as the target
+    value.
+
+    - This function is a wrapper for `show_samplings`.
+    Parameters:
+    -----------
+    res: The object returned from the optimizer with the optimization
+         parameters.
+    verbose: Level of detail in the shown information.
+             - Log.ALL shows all the sampling points.
+             - Log.BEST shows only the iterations that find better results.
+    min_width: Minimum width of the column.
+    """
+    show_sampling(
+        x=res.params_all,
+        y=res.target_all,
+        f=res.f,
+        verbose=verbose,
+        min_width=min_width,
+    )

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -36,16 +36,16 @@ def test_2D_optim():
     params = bayex.optim(f, constrains=bounds, seed=SEED, n=15, n_init=10)
     assert jnp.allclose(TARGET, params.target, rtol=1e-01)
 
-def test_optim_params_correct_output():
 
+def test_optim_params_correct_output():
     def f(x, y, z):
         return -(y ** 2) - (x - y) ** 2 + 3 * z / y - 2
 
-    bounds = dict(x=(0, 5), y=(1, 4), z=(1,20))
+    bounds = dict(x=(0, 5), y=(1, 4), z=(1, 20))
 
     param = bayex.optim(f, constrains=bounds, seed=SEED, n=2, n_init=2)
     assert type(param.target) == float
-    assert type(param.parameters) == dict
-    assert len(param.parameters) == len(bounds)
-
-
+    assert type(param.params) == dict
+    assert len(param.params) == len(bounds)
+    assert param.params_all.ndim == 2
+    assert param.target_all.size == 4


### PR DESCRIPTION
* Increases the capabilities of the OptimizerParameters namedtuple to
  store more information of the optimization process. I guess this is
  bortherline OOP, but still in the functional realm (I hope).

* Removes the printing of results as they are found. Instead, shows the
  final sampling once the optimization has finished. This makes the
  process a bit meh, so maybe a loop counter or something that tells you
  the progress will be nice to add.

* In order to show results
```
from bayex import show_results
show_results(optim_params)
```
* Added a Log level enum with 2 possible options
         - Log.ALL -> displays all the sampling points.
	 - Log.BEST -> only displays the points that have improved the
		       target function.

solves #6 

