### PR TITLE
fix: likelihood calculation was wrong due to masks

### DIFF
--- a/bayex/gp.py
+++ b/bayex/gp.py
@@ -6,6 +6,8 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.linalg import cholesky, solve_triangular
 
+MASK_VARIANCE = 1e12 # High variance for masked points to not affect the process.
+
 GPParams = namedtuple("GPParams", ["noise", "amplitude", "lengthscale"])
 GPState = namedtuple("GPState", ["params", "momentums", "scales"])
 
@@ -37,16 +39,18 @@ def gaussian_process(
 
     noise, amp, ls = jax.tree_util.tree_map(softplus, params)
 
-    ymean = jnp.mean(y, where=mask)
+    ymean = jnp.mean(y, where=mask.astype(bool))
     y = (y - ymean) * mask
     x = x / ls
     K = amp * cov(x, x, mask, mask) + (jnp.eye(n) * (noise + 1e-6))
+    K += jnp.eye(n) * (1.0 - mask) * MASK_VARIANCE
     L = cholesky(K, lower=True)
     K_inv_y = solve_triangular(L.T, solve_triangular(L, y, lower=True), lower=False)
 
     if compute_ml:
         logp = 0.5 * jnp.dot(y.T, K_inv_y)
         logp += jnp.sum(jnp.log(jnp.diag(L)))
+        logp -= jnp.sum(1.0 - mask) * 0.5 * jnp.log(MASK_VARIANCE)
         logp += (jnp.sum(mask) / 2) * jnp.log(2 * jnp.pi)
         logp += jnp.sum(-0.5 * jnp.log(2*jnp.pi) - jnp.log(amp) - jnp.log(amp)**2)
         return jnp.sum(logp)
@@ -58,6 +62,7 @@ def gaussian_process(
     mask_t = jnp.ones(len(xt))==1
     K_cross = amp * cov(x, xt, mask, mask_t)
 
+    K_inv_y = K_inv_y * mask # masking
     pred_mean = jnp.dot(K_cross.T, K_inv_y) + ymean
     v = solve_triangular(L, K_cross, lower=True)
     pred_var = amp * cov(xt, xt, mask_t, mask_t) - v.T @ v

--- a/tests/gp_test.py
+++ b/tests/gp_test.py
@@ -1,34 +1,99 @@
+import jax
 import jax.numpy as jnp
 import pytest
-from bayex.gp import GPParams, gaussian_process, exp_quadratic, cov
+from bayex import gp
 
-@pytest.mark.parametrize("x1, x2, mask, expected", [
-    (jnp.array([0]), jnp.array([0]), 1, 1),
-    (jnp.array([0]), jnp.array([1]), 1, jnp.exp(-1)),
-    (jnp.array([1]), jnp.array([1]), 0, 0),
-])
+
+@pytest.mark.parametrize(
+    "x1, x2, mask, expected",
+    [
+        (jnp.array([0]), jnp.array([0]), 1, 1),
+        (jnp.array([0]), jnp.array([1]), 1, jnp.exp(-1)),
+        (jnp.array([1]), jnp.array([1]), 0, 0),
+    ],
+)
 def test_exp_quadratic(x1, x2, mask, expected):
-    result = exp_quadratic(x1, x2, mask)
+    result = gp.exp_quadratic(x1, x2, mask)
     assert jnp.isclose(result, expected), f"Expected {expected}, got {result}"
 
-@pytest.mark.parametrize("x1, x2, mask1, mask2, expected_shape", [
-    (jnp.linspace(-5, 5, 10), jnp.linspace(-5, 5, 10), jnp.ones(10), jnp.ones(10), (10, 10)),
-    (jnp.linspace(-5, 5, 5), jnp.linspace(-5, 5, 10), jnp.ones(5), jnp.ones(10), (5, 10)),
-])
-def test_covariance_shape(x1, x2, mask1, mask2, expected_shape):
-    cov_matrix = cov(x1, x2, mask1, mask2)
-    assert cov_matrix.shape == expected_shape, f"Expected shape {expected_shape}, got {cov_matrix.shape}"
 
-@pytest.mark.parametrize("compute_ml, expected_output_type", [
-    (False, tuple),  # Expecting mean and std as output
-    (True, jnp.ndarray),  # Expecting marginal likelihood as output
-])
+@pytest.mark.parametrize(
+    "x1, x2, mask1, mask2, expected_shape",
+    [
+        (jnp.linspace(-5, 5, 10), jnp.linspace(-5, 5, 10), jnp.ones(10), jnp.ones(10), (10, 10)),
+        (jnp.linspace(-5, 5, 5), jnp.linspace(-5, 5, 10), jnp.ones(5), jnp.ones(10), (5, 10)),
+    ],
+)
+def test_covariance_shape(x1, x2, mask1, mask2, expected_shape):
+    cov_matrix = gp.cov(x1, x2, mask1, mask2)
+    assert (
+        cov_matrix.shape == expected_shape
+    ), f"Expected shape {expected_shape}, got {cov_matrix.shape}"
+
+
+@pytest.mark.parametrize(
+    "compute_ml, expected_output_type",
+    [
+        (False, tuple),  # Expecting mean and std as output
+        (True, jnp.ndarray),  # Expecting marginal likelihood as output
+    ],
+)
 def test_gaussian_process_output_type(compute_ml, expected_output_type):
-    params = GPParams(noise=0.1, amplitude=1.0, lengthscale=1.0)
+    params = gp.GPParams(noise=0.1, amplitude=1.0, lengthscale=1.0)
     x = jnp.linspace(-5, 5, 10)
     y = jnp.sin(x)
     mask = jnp.ones_like(x, dtype=bool)
     xt = jnp.array([0.0]) if not compute_ml else None
 
-    output = gaussian_process(params, x, y, mask, xt, compute_ml=compute_ml)
-    assert isinstance(output, expected_output_type), f"Output type mismatch. Expected: {expected_output_type}, got: {type(output)}"
+    output = gp.gaussian_process(params, x, y, mask, xt, compute_ml=compute_ml)
+    assert isinstance(
+        output, expected_output_type
+    ), f"Output type mismatch. Expected: {expected_output_type}, got: {type(output)}"
+
+
+@pytest.mark.parametrize("padding", [0, 1, 5, 10])
+def test_masking_in_gaussian_process(padding: int):
+
+    params = gp.GPParams(noise=0.1, amplitude=1.0, lengthscale=1.0)
+
+    x = jnp.linspace(-5, 5, 10)
+    y = jnp.sin(x)
+    mask = jnp.ones_like(x, dtype=float)
+    reference = gp.marginal_likelihood(params, x, y, mask)
+
+    x_pad, y_pad, mask_pad = jax.tree.map(
+        lambda x: jnp.pad(x, (0, padding)), (x, y, mask)
+    )
+    assert len(x_pad) == len(x) + padding, "X should be padded to 10 + padding length"
+    assert mask_pad[len(mask):].sum() == 0, "Mask should be zero for padded values"
+
+    output = gp.marginal_likelihood(params, x_pad, y_pad, mask_pad)
+
+    assert jnp.allclose(reference, output), f"Mismatch for padding={padding}"
+
+
+@pytest.mark.parametrize("padding", [0, 1, 5, 10])
+def test_masking_in_prediction(padding: int):
+
+    params = gp.GPParams(noise=0.1, amplitude=1.0, lengthscale=1.0)
+
+    x = jnp.linspace(-5, 5, 10)
+    y = jnp.sin(x)
+    mask = jnp.ones_like(x)
+    xt = jnp.linspace(-6, 6, 20)
+
+    # Reference prediction without padding
+    mean_ref, std_ref = gp.predict(params, x, y, mask, xt)
+
+    # Apply padding
+    x_pad, y_pad, mask_pad = jax.tree.map(
+        lambda a: jnp.pad(a, (0, padding)), (x, y, mask)
+    )
+
+    # Prediction with padded inputs
+    mean_pad, std_pad = gp.predict(params, x_pad, y_pad, mask_pad, xt)
+
+    assert mean_pad.shape == mean_ref.shape
+    assert std_pad.shape == std_ref.shape
+    assert jnp.allclose(mean_pad, mean_ref, atol=1e-5), f"Mean mismatch for padding={padding}"
+    assert jnp.allclose(std_pad, std_ref, atol=1e-5), f"Std mismatch for padding={padding}"


### PR DESCRIPTION
* This commit fixes that wrong by setting the variance of the masked data points to a large value (flat), and then removing their contribution from the marginal likelihood calculation.